### PR TITLE
Rename entity_search endpoint to be more specific

### DIFF
--- a/.well-known/openapi.yaml
+++ b/.well-known/openapi.yaml
@@ -188,10 +188,10 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Entity Report
-  /search:
+  /entity_search:
     post:
       description: Retrieves entity data based on a user-specified set of entity attributes.
-      operationId: search_attrs_search_post
+      operationId: entity_search_entity_search_post
       requestBody:
         content:
           application/json:
@@ -203,7 +203,7 @@ paths:
           content:
             application/json:
               schema:
-                title: Response Search Attrs Search Post
+                title: Response Entity Search Entity Search Post
                 type: object
           description: Successful Response
         '422':
@@ -212,4 +212,4 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: Search Attrs
+      summary: Entity Search

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ run:
 test:
 	pytest --cov server --cov-report term-missing -v -s tests
 test-watch:
-	ptw -- --testmon
+	ptw tests -- --testmon
 
 openapi-schema:
 	python server/openapi_schema.py

--- a/server/main.py
+++ b/server/main.py
@@ -143,8 +143,8 @@ def entity_how(
 # Search Attrs
 #
 # https://docs.senzing.com/python/3/g2engine/searching/index.html#searchbyattributes
-@app.post('/search')
-def search(
+@app.post('/entity_search')
+def entity_search(
     attrs: SearchAttributes,
     api: Annotated[SenzingAPI, Depends(api_create)],
 ) -> dict:

--- a/tests/server/test_main.py
+++ b/tests/server/test_main.py
@@ -58,8 +58,8 @@ def test_entity_how(client):
 # Search Attrs
 #
 # https://docs.senzing.com/python/3/g2engine/searching/index.html#searchbyattributes
-def test_search(client):
-    resp = client.post('/search', json=dict(NAME_FULL='Bob Smith'))
+def test_entity_search(client):
+    resp = client.post('/entity_search', json=dict(NAME_FULL='Bob Smith'))
     assert 200 == resp.status_code
     assert resp.json() == SEARCH_NAME_FULL_BOB_SMITH
 


### PR DESCRIPTION
## Why was change needed

There's no namespacing in OpenAI's function calling feature. So rename the endpoint to be specific.

## What does change improve

Avoid generic endpoint names.
